### PR TITLE
Add PayerReference parameter

### DIFF
--- a/PayBySquare.TextGenerator.NET.Tests/Code/PayBySquareOverkillTests.vb
+++ b/PayBySquare.TextGenerator.NET.Tests/Code/PayBySquareOverkillTests.vb
@@ -2,33 +2,74 @@
 <TestClass>
 Public Class PayBySquareOverkillTests
 
-    <TestMethod>
-    Sub BasicPayment()
-        Dim Gen As New PayBySquareOverkill("CZ1720100000002800266981", 1235.8D, "EUR", "654321", "PayBySquareOverkill")
-        Assert.AreEqual("00054000CUJ17AUG92PSOB3F1IA17JL9Q3C3SAU6AG42CGGIFROV0B3E34GR8M8UODIPGNAQ10LV7UEN52PVVLL5A6K1Q9F8TLUSUVBQG8JUN2TJSEKSR7POADRS3KF10", Gen.GeneratePayBySquareOverkillString)
-    End Sub
+	<TestMethod>
+	Sub BasicPayment()
+		Dim Gen As New PayBySquareOverkill("CZ1720100000002800266981", 1235.8D, "EUR", "654321", "PayBySquareOverkill")
+		Assert.AreEqual("00054000CUJ17AUG92PSOB3F1IA17JL9Q3C3SAU6AG42CGGIFROV0B3E34GR8M8UODIPGNAQ10LV7UEN52PVVLL5A6K1Q9F8TLUSUVBQG8JUN2TJSEKSR7POADRS3KF10", Gen.GeneratePayBySquareOverkillString)
+	End Sub
 
-    <TestMethod>
-    Sub ComplexPayment()
-        Dim Gen As New PayBySquareOverkill, P As Payment
-        Gen.InvoiceID = "X-4242"
-        P = New Payment
-        With P
-            .Amount = 112.35
-            .CurrencyCode = "EUR"
-            .BankAccounts.Add(New BankAccount("CZ1720100000002800266981", "FIOBCZPPXXX"))
-            .BankAccounts.Add(New BankAccount("CZ9120100000002000278810", "FIOBCZPPXXX"))
-            .VariableSymbol = "654321"
-            .ConstantSymbol = "0308"
-            .SpecificSymbol = "998877"
-            .PaymentNote = "PayBySquareOverkill note"
-            .BeneficiaryName = "Ing. Pavel Mikula"
-            .BeneficiaryAddressLine1 = "AddressOf(Pavel Mikula).FirstLine"
-            .BeneficiaryAddressLine2 = "AddressOf(Pavel Mikula).SecondLine"
-            .PaymentDueDate = New Date(2019, 1, 1)
-        End With
-        Gen.Payments.Add(P)
-        Assert.AreEqual("000FC000CQQGDBVH80212G6G8MPTRE2S9TNOA5IPVOQB7V525176J4DVMIDEA6P75S6N54TM114GH1N6RF2NQKBMSI92OMEOMQNNVBSF22KQGKNP6UL6NIARGU0MR0M3KN1R3B3UUD5O68NLOJH1R00T16C8TKFS883M4H88NEHKFALKV2QLMMKC6KLQ76CDOG7BPBTUDTA4P018IPEL6M8IEFK4LR6H2HM3HS168E6MQIAG9493RVK23HF4MQ78095R25OLGLL2CORBJJVIF1MH2I08GH71O0", Gen.GeneratePayBySquareOverkillString)
-    End Sub
+	<TestMethod>
+	Sub ComplexPayment()
+		Dim Gen As New PayBySquareOverkill, P As Payment
+		Gen.InvoiceID = "X-4242"
+		P = New Payment
+		With P
+			.Amount = 112.35
+			.CurrencyCode = "EUR"
+			.BankAccounts.Add(New BankAccount("CZ1720100000002800266981", "FIOBCZPPXXX"))
+			.BankAccounts.Add(New BankAccount("CZ9120100000002000278810", "FIOBCZPPXXX"))
+			.VariableSymbol = "654321"
+			.ConstantSymbol = "0308"
+			.SpecificSymbol = "998877"
+			.PaymentNote = "PayBySquareOverkill note"
+			.BeneficiaryName = "Ing. Pavel Mikula"
+			.BeneficiaryAddressLine1 = "AddressOf(Pavel Mikula).FirstLine"
+			.BeneficiaryAddressLine2 = "AddressOf(Pavel Mikula).SecondLine"
+			.PaymentDueDate = New Date(2019, 1, 1)
+		End With
+		Gen.Payments.Add(P)
+		Assert.AreEqual("000FC000CQQGDBVH80212G6G8MPTRE2S9TNOA5IPVOQB7V525176J4DVMIDEA6P75S6N54TM114GH1N6RF2NQKBMSI92OMEOMQNNVBSF22KQGKNP6UL6NIARGU0MR0M3KN1R3B3UUD5O68NLOJH1R00T16C8TKFS883M4H88NEHKFALKV2QLMMKC6KLQ76CDOG7BPBTUDTA4P018IPEL6M8IEFK4LR6H2HM3HS168E6MQIAG9493RVK23HF4MQ78095R25OLGLL2CORBJJVIF1MH2I08GH71O0", Gen.GeneratePayBySquareOverkillString)
+	End Sub
+
+	<TestMethod>
+	Sub PaymentWithPayerReference()
+		Dim Gen As New PayBySquareOverkill, P As Payment
+		Gen.InvoiceID = "OF20251229"
+		P = New Payment
+		With P
+			.Amount = 10.11
+			.CurrencyCode = "EUR"
+			.BankAccounts.Add(New BankAccount("CZ1720100000002800266981", "FIOBCZPPXXX"))
+			.PayerReference = "PayBySquareOverkill Payer Reference"
+			.PaymentDueDate = New Date(2025, 12, 5)
+		End With
+		Gen.Payments.Add(P)
+		Dim g = Gen.GeneratePayBySquareOverkillString
+		Assert.AreEqual("0007G0005MJCC2C4JB5171VHHRU2FJE6R9TT9T2S5AQ5IQPVUACA5DR8JL3INCMOD86FIV4R2TSUP5KOBQ46HG58I81N9ELN4TM6NDVAKSINH4R3L37HUPHQ3OV1V5IP9VO74J1UVT8S7RDL4BFEU57051AIUCHLMM4EQA10UAKAUPGAVMO9800", Gen.GeneratePayBySquareOverkillString)
+	End Sub
+
+	<TestMethod>
+	<DataRow("111111", "", Nothing)>
+	<DataRow(Nothing, "2222", Nothing)>
+	<DataRow(" ", " ", "333333")>
+	<DataRow("111111", "2222", "")>
+	<DataRow("111111", "        ", "333333")>
+	<DataRow(Nothing, "2222", "333333")>
+	<DataRow("111111", "2222", "333333")>
+	Sub InvalidPaymentWithPayerReference(VS As String, KS As String, SS As String)
+		Dim Gen As New PayBySquareOverkill
+		Dim P As New Payment
+		With P
+			.Amount = 100
+			.CurrencyCode = "EUR"
+			.BankAccounts.Add(New BankAccount("CZ1720100000002800266981", "FIOBCZPPXXX"))
+			.VariableSymbol = VS
+			.ConstantSymbol = KS
+			.SpecificSymbol = SS
+			.PayerReference = "PayBySquareOverkill Payer Reference"
+		End With
+		Gen.Payments.Add(P)
+		Assert.ThrowsExactly(Of InvalidOperationException)(Sub() Gen.GeneratePayBySquareOverkillString())
+	End Sub
 
 End Class

--- a/PayBySquare.TextGenerator.NET/Code/PayBySquareOverkill.vb
+++ b/PayBySquare.TextGenerator.NET/Code/PayBySquareOverkill.vb
@@ -27,7 +27,9 @@ Public Class PayBySquareOverkill
             TS.Append(P.VariableSymbol)
             TS.Append(P.ConstantSymbol)
             TS.Append(P.SpecificSymbol)
-            TS.Append(CStr(Nothing))        'OriginatorsReferenceInformation (VS, SS a KS in SEPA format) - only if VS, KS and SS are empty
+            TS.Append(If(String.IsNullOrWhiteSpace(P.VariableSymbol) AndAlso
+                         String.IsNullOrWhiteSpace(P.ConstantSymbol) AndAlso
+                         String.IsNullOrWhiteSpace(P.SpecificSymbol), P.PayerReference, CStr(Nothing))) 'OriginatorsReferenceInformation (VS, SS a KS in SEPA format) - only if VS, KS and SS are empty
             TS.Append(If(P.PaymentNote IsNot Nothing AndAlso P.PaymentNote.Length > 140, P.PaymentNote.Substring(0, 140), P.PaymentNote))
             TS.Append(P.BankAccounts.Count)
             For Each BA As BankAccount In P.BankAccounts

--- a/PayBySquare.TextGenerator.NET/Code/PayBySquareOverkill.vb
+++ b/PayBySquare.TextGenerator.NET/Code/PayBySquareOverkill.vb
@@ -1,71 +1,79 @@
 ﻿
 Public Class PayBySquareOverkill
 
-    Public InvoiceID As String
-    Public Payments As New List(Of Payment)
+	Public InvoiceID As String
+	Public Payments As New List(Of Payment)
 
-    Public Sub New()
-    End Sub
+	Public Sub New()
+	End Sub
 
-    Public Sub New(P As Payment)
-        Payments.Add(P)
-    End Sub
+	Public Sub New(P As Payment)
+		Payments.Add(P)
+	End Sub
 
-    Public Sub New(IBAN As String, Amount As Decimal, CurrencyCode As String, VariableSymbol As String, PaymentNote As String)
-        Me.New(New Payment(IBAN, Amount, CurrencyCode, VariableSymbol, PaymentNote))
-    End Sub
+	Public Sub New(IBAN As String, Amount As Decimal, CurrencyCode As String, VariableSymbol As String, PaymentNote As String)
+		Me.New(New Payment(IBAN, Amount, CurrencyCode, VariableSymbol, PaymentNote))
+	End Sub
 
-    Public Function GeneratePayBySquareOverkillString() As String
-        Dim TS As New TabSerializer, Crc As New Crc32, Enc As New LZMA.Lzma1Encoder, Value(), DataToCompress(), Buff() As Byte
-        TS.Append(InvoiceID)
-        TS.Append(Payments.Count)
-        For Each P As Payment In Payments
-            TS.Append(1)                'PaymentOptions= paymentorder=1, standingorder=2, directdebit=4
-            TS.Append(P.Amount.ToString.Replace(",", "."))
-            TS.Append(P.CurrencyCode)
-            TS.Append(P.PaymentDueDate)
-            TS.Append(P.VariableSymbol)
-            TS.Append(P.ConstantSymbol)
-            TS.Append(P.SpecificSymbol)
-            TS.Append(If(String.IsNullOrWhiteSpace(P.VariableSymbol) AndAlso
-                         String.IsNullOrWhiteSpace(P.ConstantSymbol) AndAlso
-                         String.IsNullOrWhiteSpace(P.SpecificSymbol), P.PayerReference, CStr(Nothing))) 'OriginatorsReferenceInformation (VS, SS a KS in SEPA format) - only if VS, KS and SS are empty
-            TS.Append(If(P.PaymentNote IsNot Nothing AndAlso P.PaymentNote.Length > 140, P.PaymentNote.Substring(0, 140), P.PaymentNote))
-            TS.Append(P.BankAccounts.Count)
-            For Each BA As BankAccount In P.BankAccounts
-                TS.Append(BA.IBAN)
-                TS.Append(BA.BIC)
-            Next
-            TS.Append(0)                    'No StandingOrderExt structure, refer to XSD schema for implementation
-            TS.Append(0)                    'No DirectDebitExt structure, refer to XSD schema for implementation
-            TS.Append(P.BeneficiaryName)
-            TS.Append(P.BeneficiaryAddressLine1)
-            TS.Append(P.BeneficiaryAddressLine2)
-        Next
-        Value = Text.Encoding.UTF8.GetBytes(TS.ToString) 'TrimEnd tabs
-        DataToCompress = Crc.ComputeHash(Value).Concat(Value).ToArray
-        Buff = New Byte() {0, 0}.Concat(BitConverter.GetBytes(CShort(DataToCompress.Length))).Concat(Enc.Encode(DataToCompress)).ToArray    '4x4 bits (Type=0, Version=0, DocumentType=0, Reserved=0) & 16 bit little endian length of DataToCompress (crc & value) & LzmaCompressedData
-        Return ToBase32Hex(Buff)
-    End Function
+	Public Function GeneratePayBySquareOverkillString() As String
+		Dim TS As New TabSerializer, Crc As New Crc32, Enc As New LZMA.Lzma1Encoder, Value(), DataToCompress(), Buff() As Byte
+		TS.Append(InvoiceID)
+		TS.Append(Payments.Count)
+		For Each P As Payment In Payments
+			ValidatePayment(P)
+			TS.Append(1)                'PaymentOptions= paymentorder=1, standingorder=2, directdebit=4
+			TS.Append(P.Amount.ToString.Replace(",", "."))
+			TS.Append(P.CurrencyCode)
+			TS.Append(P.PaymentDueDate)
+			TS.Append(P.VariableSymbol)
+			TS.Append(P.ConstantSymbol)
+			TS.Append(P.SpecificSymbol)
+			TS.Append(P.PayerReference)
+			TS.Append(If(P.PaymentNote IsNot Nothing AndAlso P.PaymentNote.Length > 140, P.PaymentNote.Substring(0, 140), P.PaymentNote))
+			TS.Append(P.BankAccounts.Count)
+			For Each BA As BankAccount In P.BankAccounts
+				TS.Append(BA.IBAN)
+				TS.Append(BA.BIC)
+			Next
+			TS.Append(0)                    'No StandingOrderExt structure, refer to XSD schema for implementation
+			TS.Append(0)                    'No DirectDebitExt structure, refer to XSD schema for implementation
+			TS.Append(P.BeneficiaryName)
+			TS.Append(P.BeneficiaryAddressLine1)
+			TS.Append(P.BeneficiaryAddressLine2)
+		Next
+		Value = Text.Encoding.UTF8.GetBytes(TS.ToString) 'TrimEnd tabs
+		DataToCompress = Crc.ComputeHash(Value).Concat(Value).ToArray
+		Buff = New Byte() {0, 0}.Concat(BitConverter.GetBytes(CShort(DataToCompress.Length))).Concat(Enc.Encode(DataToCompress)).ToArray    '4x4 bits (Type=0, Version=0, DocumentType=0, Reserved=0) & 16 bit little endian length of DataToCompress (crc & value) & LzmaCompressedData
+		Return ToBase32Hex(Buff)
+	End Function
 
-    Private Function ToBase32Hex(Buff() As Byte) As String
-        Const Base32HexCharset As String = "0123456789ABCDEFGHIJKLMNOPQRSTUV"
-        Dim CharIndex As Integer, sb As New Text.StringBuilder, B As Byte, bi, ByteIdx, BitIdx As Integer
-        For BitPos As Integer = 0 To Buff.Length * 8 Step 5 'Cist jako bitstream po 5 bitech
-            CharIndex = 0
-            For bi = 0 To 4
-                ByteIdx = (BitPos + bi) \ 8
-                BitIdx = 7 - (BitPos + bi) Mod 8
-                If ByteIdx = Buff.Length Then
-                    B = 0   'Do nasobku 5 bitu se doplnuje nulami na konci
-                Else
-                    B = Buff(ByteIdx)
-                End If
-                If (B And (1 << BitIdx)) <> 0 Then CharIndex += 1 << (4 - bi)
-            Next
-            sb.Append(Base32HexCharset(CharIndex))
-        Next
-        Return sb.ToString
-    End Function
+	Private Sub ValidatePayment(Payment As Payment)
+		If Not String.IsNullOrWhiteSpace(Payment.PayerReference) AndAlso
+		   (Not String.IsNullOrWhiteSpace(Payment.VariableSymbol) OrElse
+			Not String.IsNullOrWhiteSpace(Payment.ConstantSymbol) OrElse
+			Not String.IsNullOrWhiteSpace(Payment.SpecificSymbol)) Then
+			Throw New InvalidOperationException("PayerReference cannot be used simultaneously with any of the variable, specific, or constant symbols. If PayerReference is used, the variable, specific, and constant symbols must all be empty.")
+		End If
+	End Sub
+
+	Private Function ToBase32Hex(Buff() As Byte) As String
+		Const Base32HexCharset As String = "0123456789ABCDEFGHIJKLMNOPQRSTUV"
+		Dim CharIndex As Integer, sb As New Text.StringBuilder, B As Byte, bi, ByteIdx, BitIdx As Integer
+		For BitPos As Integer = 0 To Buff.Length * 8 Step 5 'Cist jako bitstream po 5 bitech
+			CharIndex = 0
+			For bi = 0 To 4
+				ByteIdx = (BitPos + bi) \ 8
+				BitIdx = 7 - (BitPos + bi) Mod 8
+				If ByteIdx = Buff.Length Then
+					B = 0   'Do nasobku 5 bitu se doplnuje nulami na konci
+				Else
+					B = Buff(ByteIdx)
+				End If
+				If (B And (1 << BitIdx)) <> 0 Then CharIndex += 1 << (4 - bi)
+			Next
+			sb.Append(Base32HexCharset(CharIndex))
+		Next
+		Return sb.ToString
+	End Function
 
 End Class

--- a/PayBySquare.TextGenerator.NET/Code/Payment.vb
+++ b/PayBySquare.TextGenerator.NET/Code/Payment.vb
@@ -7,7 +7,7 @@ Public Class Payment
     Public BankAccounts As New List(Of BankAccount)
 
     'Optional
-    Public VariableSymbol, ConstantSymbol, SpecificSymbol, PaymentNote, BeneficiaryName, BeneficiaryAddressLine1, BeneficiaryAddressLine2 As String
+    Public VariableSymbol, ConstantSymbol, SpecificSymbol, PaymentNote, BeneficiaryName, BeneficiaryAddressLine1, BeneficiaryAddressLine2, PayerReference As String
     Public PaymentDueDate? As Date
 
     Public Sub New()


### PR DESCRIPTION
Add PayerReference to QR generation if KS, SS anv VS are empty.

There are cases where we need to generate qr with PayerReference, but it is not supported in current implementation.

